### PR TITLE
R1-3530 : Editor Controls cleanup - Part 2

### DIFF
--- a/apps/common/main/lib/view/Header.js
+++ b/apps/common/main/lib/view/Header.js
@@ -97,9 +97,9 @@ define([
                                     '<div class="btn-slot" id="slot-hbtn-print-quick"></div>' +
                                     '<div class="btn-slot" id="slot-hbtn-download"></div>' +
                                 '</div>' +
-                                '<div class="hedset" data-layout-name="header-editMode">' +
-                                    '<div class="btn-slot" id="slot-btn-edit-mode"></div>' +
-                                '</div>' +
+                                // '<div class="hedset" data-layout-name="header-editMode">' +
+                                //     '<div class="btn-slot" id="slot-btn-edit-mode"></div>' +
+                                // '</div>' +
                                 '<div class="hedset" data-layout-name="header-users">' +
                                     // '<span class="btn-slot text" id="slot-btn-users"></span>' +
                                     '<section id="tlb-box-users" class="box-cousers dropdown">' +

--- a/apps/documenteditor/main/app/controller/Toolbar.js
+++ b/apps/documenteditor/main/app/controller/Toolbar.js
@@ -3898,7 +3898,7 @@ define([
                 //     Array.prototype.push.apply(me.toolbar.paragraphControls, drawtab.getView().getButtons());
                 // }
 
-                // toolbar-protect disabled (commented, not removed)
+                // toolbar-protect disabled (Not in use now)
                 // if ( config.canProtect ) {
                 //     tab = {action: 'protect', caption: me.toolbar.textTabProtect, layoutname: 'toolbar-protect', dataHintTitle: 'T'};
                 //     $panel = application.getController('Common.Controllers.Protection').createToolbarPanel();

--- a/apps/documenteditor/main/app/controller/Toolbar.js
+++ b/apps/documenteditor/main/app/controller/Toolbar.js
@@ -3884,16 +3884,17 @@ define([
                 //         if ($panel) me.toolbar.addTab(tab, $panel, 6);
                 //     }
                 // }
-                var drawtab = application.getController('Common.Controllers.Draw');
-                drawtab.setApi(me.api).setMode(config);
-                $panel = drawtab.createToolbarPanel();
-                if ($panel) {
-                    tab = {action: 'draw', caption: me.toolbar.textTabDraw, extcls: 'canedit', layoutname: 'toolbar-draw', dataHintTitle: 'C'};
-                    me.toolbar.addTab(tab, $panel, 2);
-                    me.toolbar.setVisible('draw', Common.UI.LayoutManager.isElementVisible('toolbar-draw'));
-                    Array.prototype.push.apply(me.toolbar.lockControls, drawtab.getView().getButtons());
-                    Array.prototype.push.apply(me.toolbar.paragraphControls, drawtab.getView().getButtons());
-                }
+                // Draw tab disabled (commented, not removed)
+                // var drawtab = application.getController('Common.Controllers.Draw');
+                // drawtab.setApi(me.api).setMode(config);
+                // $panel = drawtab.createToolbarPanel();
+                // if ($panel) {
+                //     tab = {action: 'draw', caption: me.toolbar.textTabDraw, extcls: 'canedit', layoutname: 'toolbar-draw', dataHintTitle: 'C'};
+                //     me.toolbar.addTab(tab, $panel, 2);
+                //     me.toolbar.setVisible('draw', Common.UI.LayoutManager.isElementVisible('toolbar-draw'));
+                //     Array.prototype.push.apply(me.toolbar.lockControls, drawtab.getView().getButtons());
+                //     Array.prototype.push.apply(me.toolbar.paragraphControls, drawtab.getView().getButtons());
+                // }
 
                 if ( config.canProtect ) {
                     tab = {action: 'protect', caption: me.toolbar.textTabProtect, layoutname: 'toolbar-protect', dataHintTitle: 'T'};

--- a/apps/documenteditor/main/app/controller/Toolbar.js
+++ b/apps/documenteditor/main/app/controller/Toolbar.js
@@ -3898,18 +3898,19 @@ define([
                 //     Array.prototype.push.apply(me.toolbar.paragraphControls, drawtab.getView().getButtons());
                 // }
 
-                if ( config.canProtect ) {
-                    tab = {action: 'protect', caption: me.toolbar.textTabProtect, layoutname: 'toolbar-protect', dataHintTitle: 'T'};
-                    $panel = application.getController('Common.Controllers.Protection').createToolbarPanel();
-                    if ($panel) {
-                        (config.isSignatureSupport || config.isPasswordSupport) && $panel.append($('<div class="separator long"></div>'));
-                        var doctab = application.getController('DocProtection');
-                        $panel.append(doctab.createToolbarPanel());
-                        me.toolbar.addTab(tab, $panel, 7);
-                        me.toolbar.setVisible('protect', Common.UI.LayoutManager.isElementVisible('toolbar-protect'));
-                        Array.prototype.push.apply(me.toolbar.lockControls, doctab.getView('DocProtection').getButtons());
-                    }
-                }
+                // toolbar-protect disabled (commented, not removed)
+                // if ( config.canProtect ) {
+                //     tab = {action: 'protect', caption: me.toolbar.textTabProtect, layoutname: 'toolbar-protect', dataHintTitle: 'T'};
+                //     $panel = application.getController('Common.Controllers.Protection').createToolbarPanel();
+                //     if ($panel) {
+                //         (config.isSignatureSupport || config.isPasswordSupport) && $panel.append($('<div class="separator long"></div>'));
+                //         var doctab = application.getController('DocProtection');
+                //         $panel.append(doctab.createToolbarPanel());
+                //         me.toolbar.addTab(tab, $panel, 7);
+                //         me.toolbar.setVisible('protect', Common.UI.LayoutManager.isElementVisible('toolbar-protect'));
+                //         Array.prototype.push.apply(me.toolbar.lockControls, doctab.getView('DocProtection').getButtons());
+                //     }
+                // }
 
                 var links = application.getController('Links');
                 links.setApi(me.api).setConfig({toolbar: me});

--- a/apps/documenteditor/main/app/controller/Toolbar.js
+++ b/apps/documenteditor/main/app/controller/Toolbar.js
@@ -3850,12 +3850,14 @@ define([
 
             me.toolbar.render(_.extend({isCompactView: editmode ? compactview : true}, config));
 
-            var tab = {action: 'review', caption: me.toolbar.textTabCollaboration, dataHintTitle: 'U', layoutname: 'toolbar-collaboration'};
-            var $panel = me.application.getController('Common.Controllers.ReviewChanges').createToolbarPanel();
-            if ( $panel ) {
-                me.toolbar.addTab(tab, $panel, 6);
-                me.toolbar.setVisible('review', (config.isEdit || config.canCoAuthoring && config.canComments) && Common.UI.LayoutManager.isElementVisible('toolbar-collaboration') ); // use config.canViewReview in review controller. set visible review tab in view mode only when asc_HaveRevisionsChanges
-            }
+            var tab, $panel;
+            // toolbar-collaboration disabled (Not in use now )
+            // tab = {action: 'review', caption: me.toolbar.textTabCollaboration, dataHintTitle: 'U', layoutname: 'toolbar-collaboration'};
+            // $panel = me.application.getController('Common.Controllers.ReviewChanges').createToolbarPanel();
+            // if ( $panel ) {
+            //     me.toolbar.addTab(tab, $panel, 6);
+            //     me.toolbar.setVisible('review', (config.isEdit || config.canCoAuthoring && config.canComments) && Common.UI.LayoutManager.isElementVisible('toolbar-collaboration') ); // use config.canViewReview in review controller. set visible review tab in view mode only when asc_HaveRevisionsChanges
+            // }
 
             if ( config.isEdit ) {
                 me.toolbar.setMode(config);
@@ -3884,7 +3886,7 @@ define([
                 //         if ($panel) me.toolbar.addTab(tab, $panel, 6);
                 //     }
                 // }
-                // Draw tab disabled (commented, not removed)
+                // Draw tab disabled (Not in use now )
                 // var drawtab = application.getController('Common.Controllers.Draw');
                 // drawtab.setApi(me.api).setMode(config);
                 // $panel = drawtab.createToolbarPanel();

--- a/apps/documenteditor/main/app/controller/ViewTab.js
+++ b/apps/documenteditor/main/app/controller/ViewTab.js
@@ -103,7 +103,9 @@ define([
                 },
                 'LeftMenu': {
                     'view:hide': _.bind(function (leftmenu, state) {
-                        this.view.chLeftMenu.setValue(!state, true);
+                        // Skip if #slot-chk-leftmenu removed from ViewTab template (chLeftMenu not rendered)
+                        if (this.view.chLeftMenu && this.view.chLeftMenu.cmpEl)
+                            this.view.chLeftMenu.setValue(!state, true);
                     }, this)
                 },
                 'RightMenu': {
@@ -149,12 +151,15 @@ define([
                         me.view.chStatusbar.$el.remove();
                     }
 
-                    if (config.canBrandingExt && config.customization && config.customization.leftMenu === false || !Common.UI.LayoutManager.isElementVisible('leftMenu')) {
-                        emptyGroup.push(me.view.chLeftMenu.$el.closest('.elset'));
-                        me.view.chLeftMenu.$el.remove();
-                    } else if (emptyGroup.length>0) {
-                        emptyGroup.push(me.view.chLeftMenu.$el.closest('.elset'));
-                        emptyGroup.shift().append(me.view.chLeftMenu.$el[0]);
+                    // Left menu checkbox — guard when #slot-chk-leftmenu commented out (no $el)
+                    if (me.view.chLeftMenu.$el && me.view.chLeftMenu.$el.length) {
+                        if (config.canBrandingExt && config.customization && config.customization.leftMenu === false || !Common.UI.LayoutManager.isElementVisible('leftMenu')) {
+                            emptyGroup.push(me.view.chLeftMenu.$el.closest('.elset'));
+                            me.view.chLeftMenu.$el.remove();
+                        } else if (emptyGroup.length>0) {
+                            emptyGroup.push(me.view.chLeftMenu.$el.closest('.elset'));
+                            emptyGroup.shift().append(me.view.chLeftMenu.$el[0]);
+                        }
                     }
 
                     if (!config.isEdit || config.canBrandingExt && config.customization && config.customization.rightMenu === false || !Common.UI.LayoutManager.isElementVisible('rightMenu')) {
@@ -175,8 +180,13 @@ define([
                         me.view.$el.find('.separator-rulers').remove();
                     }
 
+                    // Macros group — only remove DOM if #slot-btn-macros exists (slot may be commented in template)
                     if (!config.isEdit || config.customization && config.customization.macros===false) {
-                        me.view.$el.find('#slot-btn-macros').closest('.group').prev().addBack().remove();
+                        var $slotMacros = me.view.$el.find('#slot-btn-macros');
+                        if ($slotMacros.length) {
+                            // me.view.$el.find('#slot-btn-macros').closest('.group').prev().addBack().remove();
+                            $slotMacros.closest('.group').prev().addBack().remove();
+                        }
                     }
 
                     me.view.cmbsZoom.forEach(function (cmb) {

--- a/apps/documenteditor/main/app/template/StatusBar.template
+++ b/apps/documenteditor/main/app/template/StatusBar.template
@@ -11,8 +11,10 @@
     <div class="status-group">
         <div id="slot-status-btn-info" style="display: inline-block;"></div>
     </div>
-    <div class="status-group" style="width:100%; text-align:center;">
+     <div class="status-group" style="width:100%; text-align:center;">
+         <!--  Not in use not 
         <label id="label-action" class="status-label" data-layout-name="statusBar-actionStatus"></label>
+         -->
     </div>
     <div class="status-group cnt-flex-center" style="flex-shrink:0;">
         <div class="separator short el-edit"></div>
@@ -21,8 +23,10 @@
         <div class="separator short el-edit space"></div>
         <span id="btn-doc-spell" class="el-edit"></span>
         <div class="separator short el-edit el-lang"></div>
+        <!-- Not in use not 
         <div id="btn-doc-review" class="el-edit el-review" style="display: inline-block;"></div>
         <div class="separator short el-edit el-review"></div>
+        -->
         <div class="separator short hide-select-tools"></div>
         <button id="status-btn-select-tool" type="button" class="btn small btn-toolbar hide-select-tools" data-hint="0" data-hint-direction="top" data-hint-offset="small"><i class="icon toolbar__icon btn-select-tool">&nbsp;</i></button>
         <button id="status-btn-hand-tool" type="button" class="btn small btn-toolbar hide-select-tools" data-hint="0" data-hint-direction="top" data-hint-offset="small"><i class="icon toolbar__icon btn-hand-tool">&nbsp;</i></button>

--- a/apps/documenteditor/main/app/template/Toolbar.template
+++ b/apps/documenteditor/main/app/template/Toolbar.template
@@ -177,11 +177,15 @@
                     <span class="btn-slot text x-huge" id="slot-img-movebkwd"></span>
                     <span class="btn-slot text x-huge" id="slot-img-align"></span>
                     <span class="btn-slot text x-huge" id="slot-img-group"></span>
+                     <!-- Not in use now shapes and merge
                     <span class="btn-slot text x-huge" id="slot-shapes-merge"></span>
+                    -->
                 </div>
                 <div class="separator long"></div>
                 <div class="group">
+                    <!-- Not in use now watermark
                     <span class="btn-slot text x-huge" id="slot-btn-watermark"></span>
+                    -->
                     <span class="btn-slot text x-huge" id="slot-btn-pagecolor" data-layout-name="toolbar-layout-pagecolor"></span>
                 </div>
                 <div class="separator long"></div>

--- a/apps/documenteditor/main/app/template/Toolbar.template
+++ b/apps/documenteditor/main/app/template/Toolbar.template
@@ -101,13 +101,17 @@
                 <div class="separator long"></div>
                 <div class="group">
                     <span class="btn-slot text x-huge" id="slot-btn-insimage"></span>
+                    <!-- Not in use Now shapes , smartart and chart
                     <span class="btn-slot text x-huge" id="slot-btn-insshape"></span>
                     <span class="btn-slot text x-huge" id="slot-btn-inssmartart"></span>
                     <span class="btn-slot text x-huge" id="slot-btn-inschart"></span>
+                    -->
                 </div>
                 <div class="separator long"></div>
                 <div class="group">
+                   <!-- Not in use Now comment
                     <span class="btn-slot text x-huge slot-comment"></span>
+                    -->
                     <span class="btn-slot text x-huge slot-inshyperlink"></span>
                 </div>
                 <div class="separator long"></div>
@@ -120,8 +124,10 @@
                     <span class="btn-slot text x-huge" id="slot-btn-instextart"></span>
                     <span class="btn-slot text x-huge" id="slot-btn-dropcap"></span>
                     <span class="btn-slot text x-huge" id="slot-btn-datetime"></span>
+                    <!-- Not in use now text from file and field
                     <span class="btn-slot text x-huge" id="slot-btn-text-from-file" data-layout-name="toolbar-insert-file"></span>
                     <span class="btn-slot text x-huge" id="slot-btn-insfield" data-layout-name="toolbar-insert-field"></span>
+                    -->
                 </div>
                 <div class="separator long"></div>
                 <div class="group">

--- a/apps/documenteditor/main/app/view/Toolbar.js
+++ b/apps/documenteditor/main/app/view/Toolbar.js
@@ -175,7 +175,7 @@ define([
                                 {caption: me.textTabHome, action: 'home', extcls: 'canedit', dataHintTitle: 'H'},
                                 {caption: me.textTabInsert, action: 'ins', extcls: 'canedit', dataHintTitle: 'I'},
                                 {caption: me.textTabLayout, action: 'layout', extcls: 'canedit', layoutname: 'toolbar-layout', dataHintTitle: 'L'},
-                                {caption: me.textTabLinks, action: 'links', extcls: 'canedit', layoutname: 'toolbar-references', dataHintTitle: 'N'}
+                                // {caption: me.textTabLinks, action: 'links', extcls: 'canedit', layoutname: 'toolbar-references', dataHintTitle: 'N'}
                                 // undefined, undefined, undefined, undefined,
                             ],
                             config: config

--- a/apps/documenteditor/main/app/view/Toolbar.js
+++ b/apps/documenteditor/main/app/view/Toolbar.js
@@ -171,7 +171,7 @@ define([
                     Common.UI.Mixtbar.prototype.initialize.call(this, {
                             template: _.template(template),
                             tabs: [
-                                {caption: me.textTabFile, action: 'file', extcls: 'canedit', layoutname: 'toolbar-file', haspanel:false, dataHintTitle: 'F'},
+                                // {caption: me.textTabFile, action: 'file', extcls: 'canedit', layoutname: 'toolbar-file', haspanel:false, dataHintTitle: 'F'},
                                 {caption: me.textTabHome, action: 'home', extcls: 'canedit', dataHintTitle: 'H'},
                                 {caption: me.textTabInsert, action: 'ins', extcls: 'canedit', dataHintTitle: 'I'},
                                 {caption: me.textTabLayout, action: 'layout', extcls: 'canedit', layoutname: 'toolbar-layout', dataHintTitle: 'L'},
@@ -1852,7 +1852,7 @@ define([
                     Common.UI.Mixtbar.prototype.initialize.call(this, {
                             template: _.template(template_view),
                             tabs: [
-                                {caption: me.textTabFile, action: 'file', layoutname: 'toolbar-file', haspanel: false, dataHintTitle: 'F'}
+                                /* {caption: me.textTabFile, action: 'file', layoutname: 'toolbar-file', haspanel: false, dataHintTitle: 'F'} */
                             ],
                             config: config
                         }
@@ -3516,8 +3516,10 @@ define([
                     this.btnCollabChanges.updateHint('');
                     if (this.synchTooltip === undefined)
                         this.createSynchTip();
-
-                    this.synchTooltip.target = this.btnCollabChanges.$el.is(':visible') ? this.btnCollabChanges.$el : $('[data-layout-name=toolbar-file]', this.$el);
+                    // this.synchTooltip.target = this.btnCollabChanges.$el.is(':visible') ? this.btnCollabChanges.$el : $('[data-layout-name=toolbar-file]', this.$el);
+                    // Original fallback: $('[data-layout-name=toolbar-file]', this.$el) — no File tab when commented above; use first tab li
+                    var $fileTab = $('[data-layout-name=toolbar-file]', this.$el);
+                    this.synchTooltip.target = this.btnCollabChanges.$el.is(':visible') ? this.btnCollabChanges.$el : ($fileTab.length ? $fileTab : this.$el.find('section.tabs > ul > li.ribtab').first());
                     this.synchTooltip.show();
                 } else {
                     this.btnCollabChanges.updateHint(this.tipSynchronize + Common.Utils.String.platformKey('Ctrl+S'));

--- a/apps/documenteditor/main/app/view/ViewTab.js
+++ b/apps/documenteditor/main/app/view/ViewTab.js
@@ -86,9 +86,9 @@ define([
                 '</div>' +
             '</div>' +
             '<div class="group small">' +
-                '<div class="elset">' +
-                    '<span class="btn-slot text" id="slot-chk-leftmenu"></span>' +
-                '</div>' +
+                // '<div class="elset">' +
+                //     '<span class="btn-slot text" id="slot-chk-leftmenu"></span>' +
+                // '</div>' +
                 '<div class="elset">' +
                     '<span class="btn-slot text" id="slot-chk-rightmenu"></span>' +
                 '</div>' +
@@ -101,9 +101,9 @@ define([
                 '<div class="elset"></div>' +
             '</div>' +
             '<div class="separator long"></div>' +
-            '<div class="group">' +
-                '<span class="btn-slot text x-huge" id="slot-btn-macros"></span>' +
-            '</div>' +
+            // '<div class="group">' +
+            //     '<span class="btn-slot text x-huge" id="slot-btn-macros"></span>' +
+            // '</div>' +
         '</section>';
 
         return {
@@ -133,9 +133,12 @@ define([
                 me.chRulers.on('change', _.bind(function (checkbox, state) {
                     me.fireEvent('rulers:change', [me.chRulers, state === 'checked']);
                 }, me));
-                me.chLeftMenu.on('change', _.bind(function (checkbox, state) {
-                    me.fireEvent('leftmenu:hide', [me.chLeftMenu, state === 'checked']);
-                }, me));
+                // Left panel slot (#slot-chk-leftmenu) may be commented in template — only bind if rendered
+                if (me.chLeftMenu.cmpEl) {
+                    me.chLeftMenu.on('change', _.bind(function (checkbox, state) {
+                        me.fireEvent('leftmenu:hide', [me.chLeftMenu, state === 'checked']);
+                    }, me));
+                }
                 me.chRightMenu.on('change', _.bind(function (checkbox, state) {
                     me.fireEvent('rightmenu:hide', [me.chRightMenu, state === 'checked']);
                 }, me));
@@ -370,8 +373,16 @@ define([
                 this.chStatusbar.render($host.find('#slot-chk-statusbar'));
                 this.chToolbar.render($host.find('#slot-chk-toolbar'));
                 this.chRulers.render($host.find('#slot-chk-rulers'));
-                this.btnMacros && this.btnMacros.render($host.find('#slot-btn-macros'));
-                this.chLeftMenu.render($host.find('#slot-chk-leftmenu'));
+                // Macros slot (#slot-btn-macros) may be commented in template
+                // this.btnMacros && this.btnMacros.render($host.find('#slot-btn-macros'));
+                if (this.btnMacros && $host.find('#slot-btn-macros').length) {
+                    this.btnMacros.render($host.find('#slot-btn-macros'));
+                }
+                // Left menu checkbox slot (#slot-chk-leftmenu) may be commented in template
+                // this.chLeftMenu.render($host.find('#slot-chk-leftmenu'));
+                if ($host.find('#slot-chk-leftmenu').length) {
+                    this.chLeftMenu.render($host.find('#slot-chk-leftmenu'));
+                }
                 this.chRightMenu.render($host.find('#slot-chk-rightmenu'));
                 this.btnSelectTool && this.btnSelectTool.render($host.find('#slot-btn-select-tool-view'));
                 this.btnHandTool && this.btnHandTool.render($host.find('#slot-btn-hand-tool-view'));
@@ -406,9 +417,12 @@ define([
                 });
                 this.btnMacros && this.btnMacros.updateHint(this.tipMacros);
 
-                var value = Common.UI.LayoutManager.getInitValue('leftMenu');
-                value = (value!==undefined) ? !value : false;
-                this.chLeftMenu.setValue(!Common.localStorage.getBool("de-hidden-leftmenu", value));
+                // Left panel checkbox — skip if slot removed from template (see getPanel)
+                if (this.chLeftMenu.cmpEl) {
+                    var value = Common.UI.LayoutManager.getInitValue('leftMenu');
+                    value = (value!==undefined) ? !value : false;
+                    this.chLeftMenu.setValue(!Common.localStorage.getBool("de-hidden-leftmenu", value));
+                }
 
                 value = Common.UI.LayoutManager.getInitValue('rightMenu');
                 value = (value!==undefined) ? !value : false;


### PR DESCRIPTION
Removed the following from the EDITOR:

- File options:
- Insert --> smartart, charts, shapes, comment, field, text from file
- DRAW
- Layout - theme at end
- References
- Collaboration
- Protections
- View -> Macros

Clean up
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/a41497bf-4d09-46b4-898f-763ae2eaa8a2" />


Insert tab 
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/6d818e98-fb3f-4716-8f4b-75710509323a" />

layout tab 
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/531f5dde-8647-4cb4-a7f5-468a3211ddbe" />

view tab 
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/fff306bd-9925-4017-9282-37a37e185f63" />

Editor with template 
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/f7a1de06-6d9f-4a17-9231-d8629d4cc8f6" />




